### PR TITLE
Make ceph.conf template idempotent by sorting hash keys

### DIFF
--- a/templates/ceph.conf.erb
+++ b/templates/ceph.conf.erb
@@ -1,6 +1,6 @@
-<% @_conf.each do |section, setting_value| -%>
+<% @_conf.sort.map do |section, setting_value| -%>
 [<%= section %>]
-<% setting_value.each do |setting, value| -%>
+<% setting_value.sort.map do |setting, value| -%>
   <%= setting %> = <%= value %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This looked like the most active fork of this repo, so I wanted to offer some of our in-house changes upstream.  There are 2 PRs that you might be interested in.  These modifications were made by @nerdmagic and have been in production for over a year.

ceph.conf is rewritten every puppet run due to ruby's non-deterministic hash key ordering.

This change sorts the keys so that the ceph.conf is idempotent. Tested to work for both section and setting keys.