### PR TITLE
package options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,9 @@
 # [*package_ensure*]
 #   Ceph version to install
 #
+# [*package_options*]
+#   install_options for the Ceph package
+#
 # [*user*]
 #   Username ceph runs as
 #
@@ -78,6 +81,7 @@ class ceph (
   String $repo_version = 'luminous',
   # Package management
   String $package_ensure = 'installed',
+  String $package_options = 'undef',
   # User management
   String $user = 'ceph',
   String $group = 'ceph',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,8 @@ class ceph::install {
   assert_private()
 
   package { 'ceph':
-    ensure => $::ceph::package_ensure,
+    ensure          => $::ceph::package_ensure,
+    install_options => $::ceph::package_options,
   }
 
   if $::facts['os']['name'] == 'Ubuntu' {


### PR DESCRIPTION
Allow specific package install_options to be specified. In this case tested with...

+ceph::pkg_options: '--disablerepo=epel'

...to ensure ceph was actually installed from the ceph repos vice EPEL.  If the ceph repo fails to configure itself, the ceph packages should fail to install.  However this doesn't change existing behavior if left at default settings.